### PR TITLE
Stop running linters using node version `12.x`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,3 @@
-# Based on Node.js starter workflow
-# https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml
-
 name: Lint
 on:
   pull_request:
@@ -14,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
[Latest GitHub Actions lint run fails on 12.x](https://github.com/mozilla/sanitizer-polyfill/runs/6018031757?check_suite_focus=true). 

[Node 12 is reaching EOL](https://endoflife.date/nodejs) and [`eslint-plugin-jsdoc` has dropped support for it in v39.0.0](https://github.com/gajus/eslint-plugin-jsdoc/compare/v38.1.6...v39.0.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50)


